### PR TITLE
不要なメッセージを消去する新しいアルゴリズムを実装

### DIFF
--- a/packages/saver/src/utils/wwa_data.ts
+++ b/packages/saver/src/utils/wwa_data.ts
@@ -33,5 +33,6 @@ export class WWAConsts {
     static FILE_DATA_MAX: number = (4000 + 1000 + 1000) * 1024;
 
     // 作成ツールのソースコードには無い、データ場所の定数一覧です。
+    static MESSAGE_FIRST_CHARA: number = 10;
     static DATA_MAP: number = 90;
 }


### PR DESCRIPTION
WWAData の message で使用していないメッセージを消去するアルゴリズムを新しくします。

```
message:
  0: ""
  ...
  10: "メッセージ1"
  11: "hoge" // 使用していない
  12: "メッセージ2"
  13: "huga" // 使用していない
```

上記のメッセージの場合、従来だと下記のように変換されます。

```
message:
  0: ""
  ...
  10: "メッセージ1"
  11: ""
  12: "メッセージ2"
```

今回の変更で、下記のように整えます。

```
message:
  0: ""
  ...
  10: "メッセージ1"
  11: "メッセージ2" // 元々 12番 を参照していたパーツの属性も、 11 番に更新
```