### PR TITLE
パーツの削除機能を実装

### DIFF
--- a/packages/maker/src/parts/PartsSelect.tsx
+++ b/packages/maker/src/parts/PartsSelect.tsx
@@ -74,14 +74,18 @@ class PartsSelect extends React.Component<Props, {}> {
     }
 
     private handlePartsDelete(partsType: PartsType) {
-        const partsNumber = {
-            [PartsType.OBJECT]: this.props.objParts.number,
-            [PartsType.MAP]: this.props.mapParts.number
-        };
+        const partsNumber = (() => {
+            switch (partsType) {
+                case PartsType.OBJECT:
+                    return this.props.objParts.number;
+                case PartsType.MAP:
+                    return this.props.mapParts.number;
+            }
+        })();
 
         this.props.deleteParts({
             type: partsType,
-            number: partsNumber[partsType]
+            number: partsNumber
         });
     }
 

--- a/packages/maker/src/parts/PartsSelect.tsx
+++ b/packages/maker/src/parts/PartsSelect.tsx
@@ -9,6 +9,7 @@ import { Dispatch, bindActionCreators } from 'redux';
 import { PartsType } from '../classes/WWAData';
 import { showPartsEdit } from '../info/InfoPanelState';
 import { Button, Segment, Label, Header } from 'semantic-ui-react';
+import { deleteParts } from '../wwadata/WWADataState';
 
 interface StateProps {
     wwaData: WWAData|null;
@@ -21,7 +22,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
     return bindActionCreators({
         selectObjParts: selectObjParts,
         selectMapParts: selectMapParts,
-        showPartsEdit: showPartsEdit
+        showPartsEdit: showPartsEdit,
+        deleteParts: deleteParts
     }, dispatch);
 };
 
@@ -72,7 +74,15 @@ class PartsSelect extends React.Component<Props, {}> {
     }
 
     private handlePartsDelete(partsType: PartsType) {
+        const partsNumber = {
+            [PartsType.OBJECT]: this.props.objParts.number,
+            [PartsType.MAP]: this.props.mapParts.number
+        };
 
+        this.props.deleteParts({
+            type: partsType,
+            number: partsNumber[partsType]
+        });
     }
 
     private renderPartsList(partsType: PartsType) {

--- a/packages/maker/src/wwadata/WWADataState.ts
+++ b/packages/maker/src/wwadata/WWADataState.ts
@@ -184,12 +184,12 @@ export const WWADataReducer = reducerWithInitialState<WWAData | null>(null)
         const emptyAttribute = createEmptyPartsAttribute(payload.type);
         switch (payload.type) {
             case PartsType.OBJECT:
-                newState.objectAttribute[payload.number] = emptyAttribute;
                 newState.message[state.objectAttribute[payload.number][WWAConsts.ATR_STRING]] = "";
+                newState.objectAttribute[payload.number] = emptyAttribute;
                 break;
             case PartsType.MAP:
-                newState.mapAttribute[payload.number] = emptyAttribute;
                 newState.message[state.mapAttribute[payload.number][WWAConsts.ATR_STRING]] = "";
+                newState.mapAttribute[payload.number] = emptyAttribute;
         }
 
         return newState;

--- a/packages/maker/src/wwadata/WWADataState.ts
+++ b/packages/maker/src/wwadata/WWADataState.ts
@@ -1,5 +1,5 @@
 import { reducerWithInitialState } from "typescript-fsa-reducers";
-import { PartsType } from "../classes/WWAData";
+import { PartsType, createEmptyPartsAttribute } from "../classes/WWAData";
 import actionCreatorFactory from "typescript-fsa";
 import { WWAData } from "@wwawing/common-interface";
 import { MapFoundationField } from "../info/MapFoundation";
@@ -36,6 +36,13 @@ export const editParts = actionCreator<{
     attributes: number[],
     message: string
 }>("EDIT_PARTS");
+/**
+ * パーツを削除します。
+ */
+export const deleteParts = actionCreator<{
+    type: PartsType,
+    number: number
+}>("DELETE_PARTS");
 
 /**
  * 配列 target から指定した場所に番号を敷き詰めます。
@@ -164,6 +171,25 @@ export const WWADataReducer = reducerWithInitialState<WWAData | null>(null)
             newState.objectAttribute[payload.number] = payload.attributes;
             newState.objectAttribute[payload.number][WWAConsts.ATR_0] = payload.number;
             newState.objectAttribute[payload.number][WWAConsts.ATR_STRING] = newMessageIndex;
+        }
+
+        return newState;
+    })
+    .case(deleteParts, (state, payload) => {
+        if (state === null) {
+            return null;
+        }
+
+        const newState = Object.assign({}, state);
+        const emptyAttribute = createEmptyPartsAttribute(payload.type);
+        switch (payload.type) {
+            case PartsType.OBJECT:
+                newState.objectAttribute[payload.number] = emptyAttribute;
+                newState.message[state.objectAttribute[payload.number][WWAConsts.ATR_STRING]] = "";
+                break;
+            case PartsType.MAP:
+                newState.mapAttribute[payload.number] = emptyAttribute;
+                newState.message[state.mapAttribute[payload.number][WWAConsts.ATR_STRING]] = "";
         }
 
         return newState;


### PR DESCRIPTION
下部のパーツ一覧にある「選択パーツ削除」からパーツが削除出来るようになります。

削除で実行される内容は下記の通りです。

- 指定したパーツのパーツ属性をすべて 0 になる
- 指定したパーツに対応するメッセージが空になる
  - 文字列変数自体は削除されない (削除されるようになるには #17 のマージが必要)